### PR TITLE
[RELEASE] v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Console Buddy 0.1.4 (December 27, 2024) ##
+
+* Bug fixes
+- Console buddy was not properly loading in the test env or the debugger this is not been resolved.
+- When using resque for one off jobs the job would be assigned to a queue that does not exist. This has been resolved.
+- Documentation updates
+
 ## Console Buddy 0.1.0 (December 30, 2023) ##
 
 *  Initial Release

--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ This feature allows you to dynamically define and execute a process async using 
 **Usage**  
 ```ruby
 > ConsoleBuddy::OneOffJob.define { User.all.each { |x| x.do_long_running_thing } }
-> ConsoleBuddy::OneOffJob.perform
+> ConsoleBuddy::Job.perform_async
 ```
 
 ## Configurations and settings
@@ -276,6 +276,7 @@ ConsoleBuddy.use_in_tests = true # Do you want to load in your shortcuts and hel
 ConsoleBuddy.use_in_debuggers = true # When in a debugger like byebug should the console buddy context be loaded in?
 ConsoleBuddy.ignore_startup_errors = false # Should warnings and errors be ignored?
 ConsoleBuddy.allowed_envs = ["development", "test"] # What RACK_ENV/RAILS_ENV do we want to use this in?
+ConsoleBuddy.one_off_job_service_type = :sidekiq # What background job gem do you use? :sidekiq, :resque, and :active_job are supported
 ```
 
 ## Development

--- a/lib/console_buddy.rb
+++ b/lib/console_buddy.rb
@@ -66,7 +66,7 @@ module ConsoleBuddy
         start_buddy_in_byebug
         puts "ConsoleBuddy session started! Debugger: #{use_in_debuggers} | Test: #{current_env}" if verbose_console
       rescue ::StandardError => error
-        puts "ConsoleBuddy encountered an during startup. [Error]: #{error.message}" if ignore_startup_errors
+        puts "ConsoleBuddy encountered an during startup. [Error]: #{error.message}" unless ignore_startup_errors
       end
     end
 
@@ -103,7 +103,7 @@ module ConsoleBuddy
     end
 
     def current_env
-      ENV['RAILS_ENV'] == 'test' || ENV['RACK_ENV']
+      ENV['RAILS_ENV'] || ENV['RACK_ENV']
     end
 
     # Loads the .console_buddy/config file if present

--- a/lib/console_buddy/jobs/resque.rb
+++ b/lib/console_buddy/jobs/resque.rb
@@ -8,7 +8,7 @@ require_relative "../one_off_job"
 module ConsoleBuddy
   module Jobs
     class Resque
-      @queue = :console_buddy
+      # @queue = :console_buddy
 
       def perform(*args)
         ::ConsoleBuddy::OneOffJob.perform(*args)

--- a/lib/console_buddy/version.rb
+++ b/lib/console_buddy/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ConsoleBuddy
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
[RELEASE] v0.1.4

## Console Buddy 0.1.4 (December 27, 2024) ##

* Bug fixes
- Console buddy was not properly loading in the test env or the debugger this is not been resolved.
- When using resque for one off jobs the job would be assigned to a queue that does not exist. This has been resolved.
- Documentation updates